### PR TITLE
V1.1.50.dev

### DIFF
--- a/man/cv.grpnet.Rd
+++ b/man/cv.grpnet.Rd
@@ -80,12 +80,13 @@ The function runs \code{grpnet} \code{n_folds}+1 times; the first to get the
 of the folds omitted. The out-of-fold deviance is accumulated, and the average deviance and
 standard deviation over the folds is computed.  Note that \code{cv.grpnet}
 does NOT search for values for \code{alpha}. A specific value should be
-supplied, else \code{alpha=1} is assumed by default. If users would like to
+supplied, else \code{alpha = 1} is assumed by default. If users would like to
 cross-validate \code{alpha} as well, they should call \code{cv.grpnet} with
 a pre-computed vector \code{foldid}, and then use this same \code{foldid} vector in
 separate calls to \code{cv.grpnet} with different values of \code{alpha}.
 Note also that the results of \code{cv.grpnet} are random, since the folds
-are selected at random. Users can reduce this randomness by running
+are selected at random (unless supplied via \code{foldid}).
+Users can reduce this randomness by running
 \code{cv.grpnet} many times, and averaging the error curves.
 }
 \examples{
@@ -93,9 +94,13 @@ set.seed(0)
 n <- 100
 p <- 200
 X <- matrix(rnorm(n * p), n, p)
-y <- X[,1] * rnorm(1) + rnorm(n)
-fit <- grpnet(X, glm.gaussian(y))
-print(fit)
+y <- X[,1:25] \%*\% rnorm(25)/4 + rnorm(n)
+groups <- c(1, sample(2:199, 60, replace = FALSE))
+groups <- sort(groups)
+cvfit <- cv.grpnet(X, glm.gaussian(y), groups = groups)
+print(cvfit)
+plot(cv.fit)
+predict(cvfit, type = "nonzero")
 
 }
 \references{

--- a/man/grpnet.Rd
+++ b/man/grpnet.Rd
@@ -163,7 +163,9 @@ n <- 100
 p <- 200
 X <- matrix(rnorm(n * p), n, p)
 y <- X[,1] * rnorm(1) + rnorm(n)
-fit <- grpnet(X, glm.gaussian(y))
+groups <- c(1, sample(2:199, 60, replace = FALSE))
+groups <- sort(groups)
+fit <- grpnet(X, glm.gaussian(y), groups = groups)
 print(fit)
 
 }

--- a/man/matrix.block_diag.Rd
+++ b/man/matrix.block_diag.Rd
@@ -4,10 +4,12 @@
 \alias{matrix.block_diag}
 \title{Creates a block-diagonal matrix.}
 \usage{
-matrix.block_diag(mats, n_threads = 1)
+matrix.block_diag(mats, method = c("naive", "cov"), n_threads = 1)
 }
 \arguments{
 \item{mats}{List of matrices.}
+
+\item{method}{Method type, with  default \code{method="naive"}.}
 
 \item{n_threads}{Number of threads.}
 }
@@ -24,7 +26,12 @@ mats <- lapply(ps, function(p) {
     X <- matrix(rnorm(n * p), n, p)
     matrix.dense(t(X) \%*\% X, method="cov")
 })
-out <- matrix.block_diag(mats)
+out <- matrix.block_diag(mats, method="cov")
+mats <- lapply(ps, function(p) {
+    X <- matrix(rnorm(n * p), n, p)
+    matrix.dense(X, method="naive")
+})
+out <- matrix.block_diag(mats, method="naive")
 }
 \author{
 Trevor Hastie and James Yang\cr Maintainer: Trevor Hastie \href{mailto:hastie@stanford.edu}{hastie@stanford.edu}

--- a/man/matrix.convex_relu.Rd
+++ b/man/matrix.convex_relu.Rd
@@ -4,12 +4,14 @@
 \alias{matrix.convex_relu}
 \title{Creates a feature matrix for the convex relu problem.}
 \usage{
-matrix.convex_relu(mat, mask, n_threads = 1)
+matrix.convex_relu(mat, mask, gated = FALSE, n_threads = 1)
 }
 \arguments{
 \item{mat}{Base feature matrix. It is either a dense or sparse matrix.}
 
 \item{mask}{Boolean mask matrix.}
+
+\item{gated}{Flag to indicate whether to use the convex gated relu feature matrix.}
 
 \item{n_threads}{Number of threads.}
 }

--- a/man/predict.cv.grpnet.Rd
+++ b/man/predict.cv.grpnet.Rd
@@ -21,7 +21,7 @@ on the CV \code{object}. Alternatively \code{lambda="lambda.min"} can be used. I
 \code{lambda} is numeric, it is taken as the value(s) of \code{lambda} to be
 used.}
 
-\item{\dots}{Not used. Other arguments to predict.}
+\item{\dots}{Other arguments to code{predict.grpnet}, such at \code{type}.}
 }
 \value{
 The object returned depends on the arguments.

--- a/man/predict.grpnet.Rd
+++ b/man/predict.grpnet.Rd
@@ -62,10 +62,12 @@ n <- 100
 p <- 200
 X <- matrix(rnorm(n * p), n, p)
 y <- X[,1] * rnorm(1) + rnorm(n)
-fit <- grpnet(X, glm.gaussian(y))
+groups <- c(1, sample(2:199, 60, replace = FALSE))
+groups <- sort(groups)
+fit <- grpnet(X, glm.gaussian(y), groups = groups)
 coef(fit)
-predict(fit,newx = X[1:5,])
-predict(fit, type="nonzero")
+predict(fit,newx = X[1:5,], lambda = c(0.1, 0.05))
+predict(fit, type="nonzero", lambda = c(0.1, 0.05))
 }
 \references{
 Yang, James and Hastie, Trevor. (2024) A Fast and Scalable Pathwise-Solver for Group Lasso

--- a/src/rcpp_matrix.cpp
+++ b/src/rcpp_matrix.cpp
@@ -85,6 +85,17 @@ auto make_r_matrix_cov_s4_64(Rcpp::List args)
     return new r_matrix_cov_s4_64_t(mat);
 }
 
+auto make_r_matrix_naive_block_diag_64(Rcpp::List args)
+{
+    Rcpp::List mat_list_r = args["mats"];
+    std::vector<matrix_naive_base_64_t*> mat_list;
+    for (auto obj : mat_list_r) {
+        mat_list.push_back(Rcpp::as<r_matrix_naive_base_64_t*>(obj)->ptr.get());
+    }
+    size_t n_threads = args["n_threads"];
+    return new r_matrix_naive_block_diag_64_t(mat_list, n_threads);
+}
+
 auto make_r_matrix_naive_cconcatenate_64(Rcpp::List args)
 {
     Rcpp::List mat_list_r = args["mats"];
@@ -300,6 +311,10 @@ RCPP_MODULE(adelie_core_matrix)
         ;
 
     /* naive matrices */
+    Rcpp::class_<r_matrix_naive_block_diag_64_t>("RMatrixNaiveBlockDiag64")
+        .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")
+        .factory<Rcpp::List>(make_r_matrix_naive_block_diag_64)
+        ;
     Rcpp::class_<r_matrix_naive_cconcatenate_64_t>("RMatrixNaiveCConcatenate64")
         .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")
         .factory<Rcpp::List>(make_r_matrix_naive_cconcatenate_64)

--- a/src/rcpp_matrix.cpp
+++ b/src/rcpp_matrix.cpp
@@ -116,6 +116,31 @@ auto make_r_matrix_naive_rconcatenate_64(Rcpp::List args)
     return new r_matrix_naive_rconcatenate_64_t(mat_list);
 }
 
+auto make_r_matrix_naive_convex_gated_relu_dense_64F(Rcpp::List args)
+{
+    const Eigen::Map<dense_64F_t> mat = args["mat"];
+    const Eigen::Map<mat_bool_t> mask = args["mask"];
+    size_t n_threads = args["n_threads"];
+    return new r_matrix_naive_convex_gated_relu_dense_64F_t(
+        mat, mask, n_threads
+    );
+}
+
+auto make_r_matrix_naive_convex_gated_relu_sparse_64F(Rcpp::List args)
+{
+    const size_t rows = args["rows"];
+    const size_t cols = args["cols"];
+    const size_t nnz = args["nnz"];
+    const Eigen::Map<vec_index_t> outer = args["outer"];
+    const Eigen::Map<vec_index_t> inner = args["inner"];
+    const Eigen::Map<vec_value_t> value = args["value"];
+    const Eigen::Map<mat_bool_t> mask = args["mask"];
+    const size_t n_threads = args["n_threads"];
+    return new r_matrix_naive_convex_gated_relu_sparse_64F_t(
+        rows, cols, nnz, outer, inner, value, mask, n_threads
+    );
+}
+
 auto make_r_matrix_naive_convex_relu_dense_64F(Rcpp::List args)
 {
     const Eigen::Map<dense_64F_t> mat = args["mat"];
@@ -270,6 +295,8 @@ RCPP_MODULE(adelie_core_matrix)
         .method("cov", &r_matrix_naive_base_64_t::cov)
         .method("sq_mul", &r_matrix_naive_base_64_t::sq_mul)
         .method("sp_tmul", &r_matrix_naive_base_64_t::sp_tmul)
+        .method("mean", &r_matrix_naive_base_64_t::mean)
+        .method("var", &r_matrix_naive_base_64_t::var)
         .property("rows", &r_matrix_naive_base_64_t::rows)
         .property("cols", &r_matrix_naive_base_64_t::cols)
         ;
@@ -322,6 +349,14 @@ RCPP_MODULE(adelie_core_matrix)
     Rcpp::class_<r_matrix_naive_rconcatenate_64_t>("RMatrixNaiveRConcatenate64")
         .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")
         .factory<Rcpp::List>(make_r_matrix_naive_rconcatenate_64)
+        ;
+    Rcpp::class_<r_matrix_naive_convex_gated_relu_dense_64F_t>("RMatrixNaiveConvexGatedReluDense64F")
+        .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")
+        .factory<Rcpp::List>(make_r_matrix_naive_convex_gated_relu_dense_64F)
+        ;
+    Rcpp::class_<r_matrix_naive_convex_gated_relu_sparse_64F_t>("RMatrixNaiveConvexGatedReluSparse64F")
+        .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")
+        .factory<Rcpp::List>(make_r_matrix_naive_convex_gated_relu_sparse_64F)
         ;
     Rcpp::class_<r_matrix_naive_convex_relu_dense_64F_t>("RMatrixNaiveConvexReluDense64F")
         .derives<r_matrix_naive_base_64_t>("RMatrixNaiveBase64")

--- a/src/rcpp_matrix.h
+++ b/src/rcpp_matrix.h
@@ -13,6 +13,7 @@
 #include <adelie_core/matrix/matrix_naive_base.ipp>
 #include <adelie_core/matrix/matrix_naive_block_diag.ipp>
 #include <adelie_core/matrix/matrix_naive_concatenate.ipp>
+#include <adelie_core/matrix/matrix_naive_convex_gated_relu.ipp>
 #include <adelie_core/matrix/matrix_naive_convex_relu.ipp>
 #include <adelie_core/matrix/matrix_naive_dense.ipp>
 #include <adelie_core/matrix/matrix_naive_interaction.ipp>
@@ -323,6 +324,30 @@ public:
             ADELIE_CORE_S4_PURE_OVERRIDE(sp_tmul, _mat, v)
         ).transpose();
     }
+
+    void mean(
+        const Eigen::Ref<const vec_value_t>& weights,
+        Eigen::Ref<vec_value_t> out
+    ) override
+    {
+        const Eigen::Map<colvec_value_t> weights_r(const_cast<value_t*>(weights.data()), weights.size());
+        out = Rcpp::as<Eigen::Map<colvec_value_t>>(
+            ADELIE_CORE_S4_PURE_OVERRIDE(mean, _mat, weights_r)
+        );
+    }
+
+    void var(
+        const Eigen::Ref<const vec_value_t>& centers,
+        const Eigen::Ref<const vec_value_t>& weights,
+        Eigen::Ref<vec_value_t> out
+    ) override
+    {
+        const Eigen::Map<colvec_value_t> centers_r(const_cast<value_t*>(centers.data()), centers.size());
+        const Eigen::Map<colvec_value_t> weights_r(const_cast<value_t*>(weights.data()), weights.size());
+        out = Rcpp::as<Eigen::Map<colvec_value_t>>(
+            ADELIE_CORE_S4_PURE_OVERRIDE(var, _mat, centers_r, weights_r)
+        );
+    }
 };
 
 } // namespace matrix
@@ -344,6 +369,8 @@ using matrix_naive_base_64_t = ad::matrix::MatrixNaiveBase<double, int>;
 using matrix_naive_block_diag_64_t = ad::matrix::MatrixNaiveBlockDiag<double, int>;
 using matrix_naive_cconcatenate_64_t = ad::matrix::MatrixNaiveCConcatenate<double, int>;
 using matrix_naive_rconcatenate_64_t = ad::matrix::MatrixNaiveRConcatenate<double, int>;
+using matrix_naive_convex_gated_relu_dense_64F_t = ad::matrix::MatrixNaiveConvexGatedReluDense<ad::util::colmat_type<double>, ad::util::colmat_type<int>, int>;
+using matrix_naive_convex_gated_relu_sparse_64F_t = ad::matrix::MatrixNaiveConvexGatedReluSparse<Eigen::SparseMatrix<double, Eigen::ColMajor, int>, ad::util::colmat_type<int>, int>;
 using matrix_naive_convex_relu_dense_64F_t = ad::matrix::MatrixNaiveConvexReluDense<ad::util::colmat_type<double>, ad::util::colmat_type<int>, int>;
 using matrix_naive_convex_relu_sparse_64F_t = ad::matrix::MatrixNaiveConvexReluSparse<Eigen::SparseMatrix<double, Eigen::ColMajor, int>, ad::util::colmat_type<int>, int>;
 using matrix_naive_dense_64F_t = ad::matrix::MatrixNaiveDense<ad::util::colmat_type<double>, int>;
@@ -603,6 +630,25 @@ public:
         [&]() { ADELIE_CORE_PIMPL_OVERRIDE(sp_tmul, v, out); }();
         return outT;
     }
+
+    vec_value_t mean(
+        const Eigen::Map<vec_value_t>& weights
+    ) 
+    {
+        vec_value_t out(cols());
+        [&]() { ADELIE_CORE_PIMPL_OVERRIDE(mean, weights, out); }();
+        return out;
+    }
+
+    vec_value_t var(
+        const Eigen::Map<vec_value_t>& centers,
+        const Eigen::Map<vec_value_t>& weights
+    ) 
+    {
+        vec_value_t out(cols());
+        [&]() { ADELIE_CORE_PIMPL_OVERRIDE(var, centers, weights, out); }();
+        return out;
+    }
 };
 
 ADELIE_CORE_PIMPL_DERIVED(RMatrixConstraintDense64F, RMatrixConstraintBase64, matrix_constraint_dense_64F_t,)
@@ -618,6 +664,8 @@ ADELIE_CORE_PIMPL_DERIVED(RMatrixCovS464, RMatrixCovBase64, matrix_cov_s4_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveBlockDiag64, RMatrixNaiveBase64, matrix_naive_block_diag_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveCConcatenate64, RMatrixNaiveBase64, matrix_naive_cconcatenate_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveRConcatenate64, RMatrixNaiveBase64, matrix_naive_rconcatenate_64_t,)
+ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveConvexGatedReluDense64F, RMatrixNaiveBase64, matrix_naive_convex_gated_relu_dense_64F_t,)
+ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveConvexGatedReluSparse64F, RMatrixNaiveBase64, matrix_naive_convex_gated_relu_sparse_64F_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveConvexReluDense64F, RMatrixNaiveBase64, matrix_naive_convex_relu_dense_64F_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveConvexReluSparse64F, RMatrixNaiveBase64, matrix_naive_convex_relu_sparse_64F_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveDense64F, RMatrixNaiveBase64, matrix_naive_dense_64F_t,)
@@ -655,6 +703,8 @@ RCPP_EXPOSED_CLASS(RMatrixNaiveBase64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveBlockDiag64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveCConcatenate64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveRConcatenate64)
+RCPP_EXPOSED_CLASS(RMatrixNaiveConvexGatedReluDense64F)
+RCPP_EXPOSED_CLASS(RMatrixNaiveConvexGatedReluSparse64F)
 RCPP_EXPOSED_CLASS(RMatrixNaiveConvexReluDense64F)
 RCPP_EXPOSED_CLASS(RMatrixNaiveConvexReluSparse64F)
 RCPP_EXPOSED_CLASS(RMatrixNaiveDense64F)
@@ -686,6 +736,8 @@ using r_matrix_naive_base_64_t = RMatrixNaiveBase64;
 using r_matrix_naive_block_diag_64_t = RMatrixNaiveBlockDiag64;
 using r_matrix_naive_cconcatenate_64_t = RMatrixNaiveCConcatenate64;
 using r_matrix_naive_rconcatenate_64_t = RMatrixNaiveRConcatenate64;
+using r_matrix_naive_convex_gated_relu_dense_64F_t = RMatrixNaiveConvexGatedReluDense64F;
+using r_matrix_naive_convex_gated_relu_sparse_64F_t = RMatrixNaiveConvexGatedReluSparse64F;
 using r_matrix_naive_convex_relu_dense_64F_t = RMatrixNaiveConvexReluDense64F;
 using r_matrix_naive_convex_relu_sparse_64F_t = RMatrixNaiveConvexReluSparse64F;
 using r_matrix_naive_dense_64F_t = RMatrixNaiveDense64F;

--- a/src/rcpp_matrix.h
+++ b/src/rcpp_matrix.h
@@ -11,6 +11,7 @@
 #include <adelie_core/matrix/matrix_cov_lazy_cov.ipp>
 #include <adelie_core/matrix/matrix_cov_sparse.ipp>
 #include <adelie_core/matrix/matrix_naive_base.ipp>
+#include <adelie_core/matrix/matrix_naive_block_diag.ipp>
 #include <adelie_core/matrix/matrix_naive_concatenate.ipp>
 #include <adelie_core/matrix/matrix_naive_convex_relu.ipp>
 #include <adelie_core/matrix/matrix_naive_dense.ipp>
@@ -340,6 +341,7 @@ using matrix_cov_sparse_64F_t = ad::matrix::MatrixCovSparse<Eigen::SparseMatrix<
 using matrix_cov_s4_64_t = ad::matrix::MatrixCovS4<double, int>;
 
 using matrix_naive_base_64_t = ad::matrix::MatrixNaiveBase<double, int>;
+using matrix_naive_block_diag_64_t = ad::matrix::MatrixNaiveBlockDiag<double, int>;
 using matrix_naive_cconcatenate_64_t = ad::matrix::MatrixNaiveCConcatenate<double, int>;
 using matrix_naive_rconcatenate_64_t = ad::matrix::MatrixNaiveRConcatenate<double, int>;
 using matrix_naive_convex_relu_dense_64F_t = ad::matrix::MatrixNaiveConvexReluDense<ad::util::colmat_type<double>, ad::util::colmat_type<int>, int>;
@@ -613,6 +615,7 @@ ADELIE_CORE_PIMPL_DERIVED(RMatrixCovLazyCov64F, RMatrixCovBase64, matrix_cov_laz
 ADELIE_CORE_PIMPL_DERIVED(RMatrixCovSparse64F, RMatrixCovBase64, matrix_cov_sparse_64F_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixCovS464, RMatrixCovBase64, matrix_cov_s4_64_t,)
 
+ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveBlockDiag64, RMatrixNaiveBase64, matrix_naive_block_diag_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveCConcatenate64, RMatrixNaiveBase64, matrix_naive_cconcatenate_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveRConcatenate64, RMatrixNaiveBase64, matrix_naive_rconcatenate_64_t,)
 ADELIE_CORE_PIMPL_DERIVED(RMatrixNaiveConvexReluDense64F, RMatrixNaiveBase64, matrix_naive_convex_relu_dense_64F_t,)
@@ -649,6 +652,7 @@ RCPP_EXPOSED_CLASS(RMatrixCovSparse64F)
 RCPP_EXPOSED_CLASS(RMatrixCovS464)
 
 RCPP_EXPOSED_CLASS(RMatrixNaiveBase64)
+RCPP_EXPOSED_CLASS(RMatrixNaiveBlockDiag64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveCConcatenate64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveRConcatenate64)
 RCPP_EXPOSED_CLASS(RMatrixNaiveConvexReluDense64F)
@@ -679,6 +683,7 @@ using r_matrix_cov_sparse_64F_t = RMatrixCovSparse64F;
 using r_matrix_cov_s4_64_t = RMatrixCovS464;
 
 using r_matrix_naive_base_64_t = RMatrixNaiveBase64;
+using r_matrix_naive_block_diag_64_t = RMatrixNaiveBlockDiag64;
 using r_matrix_naive_cconcatenate_64_t = RMatrixNaiveCConcatenate64;
 using r_matrix_naive_rconcatenate_64_t = RMatrixNaiveRConcatenate64;
 using r_matrix_naive_convex_relu_dense_64F_t = RMatrixNaiveConvexReluDense64F;

--- a/tests/testthat/test_matrix.R
+++ b/tests/testthat/test_matrix.R
@@ -9,7 +9,11 @@ test_that("matrix.block_diag", {
         X <- matrix(rnorm(n * p), n, p)
         matrix.dense(t(X) %*% X, method="cov")
     })
-    expect_error(matrix.block_diag(mats), NA)
+    expect_error(matrix.block_diag(mats, method="cov"), NA)
+    mats <- lapply(ps, function(p) {
+        matrix(rnorm(n * p), n, p)
+    })
+    expect_error(matrix.block_diag(mats, method="naive"), NA)
 })
 
 test_that("matrix.concatenate", {


### PR DESCRIPTION
- Add mean/var functions to each naive matrix class.
- Add fix to `matrix.standardize` using the mean and var function instead.
- Add `matrix.block_diag` for naive matrix.
- Update docs.
- Add `matrix.convex_relu` for gated relu matrices.
- Now tracking v1.1.50 in Python package.