### PR TITLE
Zero variance

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -48,3 +48,4 @@
 ^CRAN-SUBMISSION$
 ^tests/*
 ^vignettes/assets/snippets.rmd$
+^debug/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ inst/doc
 src/*.o
 src/*.so
 
+.Rproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ inst/doc
 /doc/
 /Meta/
 *CRAN-SUBMISSION
+src/*.o
+src/*.so
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: adelie
 Title: Group Lasso and Elastic Net Solver for Generalized Linear Models
 Version: 1.0.10
-Date: 2026-05-28
+Date: 2026-06-03
 Authors@R: c(
     person("James", "Yang", role = c("aut", "cph")),
     person("Trevor", "Hastie", email="hastie@stanford.edu", role = c("aut", "cph", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: adelie
 Title: Group Lasso and Elastic Net Solver for Generalized Linear Models
-Version: 1.0.9
-Date: 2026-05-07
+Version: 1.0.10
+Date: 2026-05-28
 Authors@R: c(
     person("James", "Yang", role = c("aut", "cph")),
     person("Trevor", "Hastie", email="hastie@stanford.edu", role = c("aut", "cph", "cre")),
@@ -14,7 +14,7 @@ Description: Extremely efficient procedures for fitting the entire group lasso a
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 LinkingTo: 
     Rcpp,
     RcppEigen

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,16 @@
   get turned into Inf. What we do instead is change the variance to
   Inf, and those variables become all 0 and are given zero
   coefficients. This problem can exhibit during CV. 
+
+* Fixed the dense-matrix `sp_tmul` so that its serial path honors
+  `n_threads`. Its `n_threads = 1` branch ran a raw Eigen product that
+  ignored the requested thread count and fell back to Eigen's global
+  default (all cores), inflating example CPU time to `user/elapsed`
+  ~10x with no wall-clock gain on a many-core machine (the source of
+  CRAN's gcc-16 R-devel "CPU time > 2.5 times elapsed" NOTE). The
+  `inst/adelie` submodule points at the one-line fix on a forked branch
+  (`bnaras/adelie@zero-variance`). Investigation notes and a Docker
+  reprex live in `debug/` (excluded from the package tarball).
   
 # adelie 1.0.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # adelie (development version)
+# adelie 1.0.10
 
+* Fixed an issue with standardization. Variables with zero variance
+  get turned into Inf. What we do instead is change the variance to
+  Inf, and those variables become all 0 and are given zero
+  coefficients. This problem can exhibit during CV. 
+  
 # adelie 1.0.9
 
 * Fixed an infinite loop in `grpnet()` and `cv.grpnet()` triggered by

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -605,11 +605,13 @@ matrix.standardize <- function(
     if (is_centers_none) {
         centers <- mat$mean(weights)
     }
-    if (is.null(scales)) {
-        vars <- mat$var(centers, weights)
+    if (is.null(scales)) { ## Standardize with variance irrespective of centers
+        centers.var <- if(is_centers_none) centers
+                       else mat$mean(weights)
+        vars <- mat$var(centers.var, weights)
+        vars[vars <= .Machine$double.eps] <- Inf
         scales <- sqrt((n / (n - ddof)) * vars)
     }
-
     centers <- as.numeric(centers)
     scales <- as.numeric(scales)
     input <- list(

--- a/adelie-r.Rproj
+++ b/adelie-r.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/debug/cran-gcc16-debian/Dockerfile
+++ b/debug/cran-gcc16-debian/Dockerfile
@@ -1,0 +1,90 @@
+FROM --platform=linux/amd64 debian:sid
+
+# ------------------------------------------------------------------------------
+# Reproduce CRAN's CRAN_pretest box for `adelie`:
+#
+#   * R Under development (unstable)  (r90083, 2026-05-27 on CRAN)
+#   * platform x86_64-pc-linux-gnu
+#   * Debian GNU/Linux forky/sid
+#   * compiled by gcc-16 (Debian 16-2026xxxx-x), a prerelease GCC 16 snapshot
+#
+# We use whatever gcc-16 snapshot sid currently ships and build R-devel from
+# source with it, so the package's own C++ (Rcpp / RcppEigen / Eigen) is also
+# compiled by gcc-16 at install time (the compiler is baked into R's Makeconf).
+# ------------------------------------------------------------------------------
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      gcc-16 g++-16 gfortran-16 \
+      make \
+      ca-certificates wget curl subversion rsync \
+      xz-utils bzip2 file patch \
+      libreadline-dev \
+      libpcre2-dev \
+      zlib1g-dev \
+      libbz2-dev \
+      liblzma-dev \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      libxml2-dev \
+      libicu-dev \
+      libpng-dev libjpeg-dev libtiff-dev \
+      libcairo2-dev \
+      libuv1-dev \
+      locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# C.UTF-8 matches CRAN's "session charset: UTF-8".
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# Record the exact gcc-16 snapshot this image ended up with.
+RUN gcc-16 --version && gfortran-16 --version
+
+# ------------------------------------------------------------------------------
+# Build R-devel from svn trunk with gcc-16.
+# ------------------------------------------------------------------------------
+
+WORKDIR /opt/src
+RUN svn checkout https://svn.r-project.org/R/trunk R-devel
+
+WORKDIR /opt/src/R-devel
+RUN ./tools/rsync-recommended
+
+# No --with-blas / --with-lapack => R's internal reference BLAS (libRblas),
+# matching a vanilla source build. Recommended packages are kept (gives Matrix).
+RUN ./configure \
+      --prefix=/opt/R/devel-gcc16 \
+      --enable-R-shlib \
+      --with-readline \
+      --with-x=no \
+      CC=gcc-16 \
+      CXX=g++-16 \
+      FC=gfortran-16 \
+      F77=gfortran-16
+
+RUN make -j"$(nproc)"
+RUN make install
+
+ENV PATH="/opt/R/devel-gcc16/bin:${PATH}"
+ENV R_HOME="/opt/R/devel-gcc16/lib/R"
+
+# Symlink R/Rscript into /usr/local/bin so they are found even by login shells
+# (`bash -lc`), whose /etc/profile resets PATH and would otherwise drop the
+# ENV PATH above.
+RUN ln -sf /opt/R/devel-gcc16/bin/R /opt/R/devel-gcc16/bin/Rscript /usr/local/bin/
+
+# Default CRAN mirror for in-container installs.
+RUN echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' \
+      >> /opt/R/devel-gcc16/lib/R/etc/Rprofile.site
+
+# ------------------------------------------------------------------------------
+# Sanity check: confirm R-devel is compiled by gcc-16 and the package toolchain
+# (CC/CXX in Makeconf) points at gcc-16.
+# ------------------------------------------------------------------------------
+RUN Rscript -e 'cat(R.version.string, "\n"); \
+                cat("platform =", R.version$platform, "\n"); \
+                cat("BLAS =", extSoftVersion()[["BLAS"]], "\n")' \
+ && echo "--- Makeconf compilers ---" \
+ && grep -E "^(CC|CXX|CXX17|FC|F77) =" /opt/R/devel-gcc16/lib/R/etc/Makeconf

--- a/debug/cran-gcc16-debian/omp-thread-experiment.R
+++ b/debug/cran-gcc16-debian/omp-thread-experiment.R
@@ -1,0 +1,41 @@
+# Isolate the source of the "CPU time > 2.5 x elapsed" NOTE for grpnet/cv.grpnet.
+#
+# Hypothesis: with the example default n_threads = 1, adelie's own OpenMP loops
+# run single-threaded, but Eigen's built-in OpenMP GEMM parallelization is
+# uncapped and defaults to omp_get_max_threads() = all cores. If so, capping
+# OpenMP threads should collapse the user/elapsed ratio.
+#
+# Run from the shell under three conditions:
+#   Rscript ...                          # OMP_NUM_THREADS unset  -> expect ratio ~#cores
+#   OMP_NUM_THREADS=1   Rscript ...      # expect ratio ~1
+#   OMP_THREAD_LIMIT=2  Rscript ...      # CRAN's check cap; expect ratio <~2
+
+suppressPackageStartupMessages(library(adelie))
+
+cat("OMP_NUM_THREADS =", Sys.getenv("OMP_NUM_THREADS", "<unset>"),
+    " OMP_THREAD_LIMIT =", Sys.getenv("OMP_THREAD_LIMIT", "<unset>"),
+    " detectCores =", parallel::detectCores(), "\n\n")
+
+# Eval the expression unevaluated (avoid R promise-caching), warm up once, then
+# time the median of several fresh evaluations so a ~0.3s fit is measured cleanly.
+run <- function(label, expr, reps = 5) {
+  e  <- substitute(expr)
+  pf <- parent.frame()
+  eval(e, pf)                                   # warm up
+  tt <- system.time(for (i in seq_len(reps)) eval(e, pf))
+  u <- tt[["user.self"]] / reps
+  s <- tt[["sys.self"]]  / reps
+  el <- tt[["elapsed"]]  / reps
+  cat(sprintf("%-12s  user=%7.3f  sys=%6.3f  elapsed=%7.3f  ratio=%6.2f\n",
+              label, u, s, el, if (el > 0) u / el else NA))
+}
+
+## --- grpnet.Rd example data ---
+set.seed(0)
+n <- 100; p <- 200
+X <- matrix(rnorm(n * p), n, p)
+y <- X[, 1] * rnorm(1) + rnorm(n)
+groups <- sort(c(1, sample(2:199, 60, replace = FALSE)))
+
+run("grpnet",    grpnet(X, glm.gaussian(y), groups = groups))
+run("cv.grpnet", cv.grpnet(X, glm.gaussian(y), groups = groups))

--- a/debug/cran-gcc16-debian/real-examples-timing.R
+++ b/debug/cran-gcc16-debian/real-examples-timing.R
@@ -1,0 +1,68 @@
+# Run the ACTUAL Rd example blocks for grpnet and cv.grpnet (verbatim, including
+# the embedded plot() calls, which R CMD check also times), and report the
+# user/system/elapsed/ratio exactly as the CRAN "examples" NOTE does.
+#
+# Conditions are set by the caller via env vars:
+#   (unset)              -> OMP at default (all cores)
+#   OMP_THREAD_LIMIT=2   -> CRAN's incoming-check cap
+#
+# Plots go to a throwaway pdf device so plotting cost is included but no window
+# is needed (this is what R CMD check does).
+
+suppressPackageStartupMessages(library(adelie))
+cat("adelie", as.character(packageVersion("adelie")),
+    "| OMP_NUM_THREADS=", Sys.getenv("OMP_NUM_THREADS","<unset>"),
+    "| OMP_THREAD_LIMIT=", Sys.getenv("OMP_THREAD_LIMIT","<unset>"),
+    "| detectCores=", parallel::detectCores(), "\n", sep=" ")
+
+pdf(tempfile(fileext = ".pdf"))   # absorb plot() output, like R CMD check
+on.exit(dev.off())
+
+## ---- grpnet.Rd example (verbatim) ----
+grpnet_example <- function() {
+  set.seed(0)
+  n <- 100
+  p <- 200
+  X <- matrix(rnorm(n * p), n, p)
+  y <- X[,1] * rnorm(1) + rnorm(n)
+  groups <- c(1, sample(2:199, 60, replace = FALSE))
+  groups <- sort(groups)
+  print(groups)
+  fit <- grpnet(X, glm.gaussian(y), groups = groups)
+  print(fit)
+  plot(fit)
+  coef(fit)
+  cvfit  <- cv.grpnet(X, glm.gaussian(y), groups = groups)
+  print(cvfit)
+  plot(cvfit)
+  predict(cvfit,newx=X[1:5,], lambda="lambda.min")
+}
+
+## ---- cv.grpnet.Rd example (verbatim) ----
+cvgrpnet_example <- function() {
+  set.seed(0)
+  n <- 100
+  p <- 200
+  X <- matrix(rnorm(n * p), n, p)
+  y <- X[,1:25] %*% rnorm(25)/4 + rnorm(n)
+  groups <- c(1, sample(2:199, 60, replace = FALSE))
+  groups <- sort(groups)
+  cvfit <- cv.grpnet(X, glm.gaussian(y), groups = groups)
+  print(cvfit)
+  plot(cvfit)
+  predict(cvfit, newx = X[1:5,])
+  predict(cvfit, type = "nonzero")
+}
+
+time_once <- function(label, fn) {
+  invisible(capture.output(fn()))                # warm up, swallow prints
+  for (rep in 1:3) {
+    tt <- system.time(invisible(capture.output(fn())))
+    u <- tt[["user.self"]]; s <- tt[["sys.self"]]; el <- tt[["elapsed"]]
+    cat(sprintf("%-12s rep%d  user=%7.3f  sys=%6.3f  elapsed=%7.3f  ratio=%6.2f\n",
+                label, rep, u, s, el, if (el > 0) u/el else NA))
+  }
+}
+
+time_once("grpnet",    grpnet_example)
+time_once("cv.grpnet", cvgrpnet_example)

--- a/debug/cran-gcc16-debian/sptmul-nthreads-confirm.R
+++ b/debug/cran-gcc16-debian/sptmul-nthreads-confirm.R
@@ -1,0 +1,30 @@
+# Confirm matrix_naive_dense::sp_tmul honors n_threads on the PATCHED build.
+# Build the dense matrix with a chosen n_threads (as predict() does), then call
+# sp_tmul on a sparse v large enough that row-parallelism is real work.
+#   n_threads=1 -> serial branch (my guard): ratio ~1, elapsed = baseline
+#   n_threads=8 -> else branch, omp_parallel_for over rows with 8 threads:
+#                  elapsed should DROP and user/elapsed ratio should climb to ~8
+suppressPackageStartupMessages({library(adelie); library(Matrix)})
+set.seed(0)
+n <- 2000; p <- 2000; nlam <- 200
+X <- matrix(rnorm(n * p), n, p)
+
+## sparse v: nlam x p, ~30% nonzero (rows = lambdas, like an interpolated path)
+B <- matrix(rnorm(nlam * p) * (matrix(runif(nlam * p), nlam, p) < 0.30), nlam, p)
+betas <- as(as(B, "CsparseMatrix"), "RsparseMatrix")
+
+cat("adelie", as.character(packageVersion("adelie")),
+    "| detectCores=", parallel::detectCores(),
+    "| X =", n, "x", p, "| v =", nlam, "x", p, "(sparse)\n")
+
+reps <- 20
+for (T in c(1, 8, 16)) {
+  md <- matrix.dense(X, method = "naive", n_threads = T)   # object carries _n_threads = T
+  invisible(md$sp_tmul(betas))                              # warm up
+  tt <- system.time(for (i in seq_len(reps)) invisible(md$sp_tmul(betas)))
+  u <- tt[["user.self"]]; el <- tt[["elapsed"]]
+  cat(sprintf("n_threads=%2d  sp_tmul x%d  user=%7.3f  elapsed=%7.3f  ratio=%5.2f  speedup_vs_T1=%s\n",
+              T, reps, u, el, u/el,
+              if (T == 1) "1.00x(ref)" else sprintf("%.2fx", get0("el1", ifnotfound=el)/el)))
+  if (T == 1) el1 <- el
+}

--- a/debug/cran-gcc16-repro.qmd
+++ b/debug/cran-gcc16-repro.qmd
@@ -1,0 +1,328 @@
+---
+title: "Reproducing CRAN's gcc-16 / R-devel Pretest for adelie"
+format: gfm
+---
+
+This note records the Docker setup used to investigate the NOTE `adelie`
+showed on CRAN's `CRAN_pretest` machine, and the root cause and one-line
+fix it led to.
+
+## Target environment
+
+The CRAN pretest reported:
+
+```text
+* using R Under development (unstable) (2026-05-27 r90083)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc-16 (Debian 16-20260425-1) 16.0.1 20260425 (prerelease) [gcc-16 r16-8812-gd9c07462a22]
+    GNU Fortran (Debian 16-20260425-1) 16.0.1 20260425 (prerelease) [gcc-16 r16-8812-gd9c07462a22]
+* running under: Debian GNU/Linux forky/sid
+* using session charset: UTF-8
+```
+
+Key properties this image reproduces:
+
+- Debian forky/sid (`debian:sid`), x86_64
+- **gcc-16** as the C/C++/Fortran compiler
+- R-devel built **from source with gcc-16**, so `adelie`'s own C++
+  (Rcpp / RcppEigen / Eigen) is also compiled by gcc-16 at install time
+- R's internal reference BLAS (`libRblas`)
+- `C.UTF-8` locale
+
+Deliberate simplifications (we are chasing a **runtime/test behavior**, not
+a bit-for-bit toolchain match):
+
+- We use whatever gcc-16 snapshot Debian sid ships *now*, not the exact
+  `16-20260425-1` snapshot. Pin via `snapshot.debian.org` only if the
+  behavior proves snapshot-sensitive.
+- R-devel is the current svn trunk, not exactly r90083.
+
+Note: this runs under `linux/amd64` emulation on Apple Silicon. Rosetta/QEMU
+reproduce SSE2 double arithmetic faithfully, which is what R and Eigen use;
+this is adequate for a runtime/threading test.
+
+## Directory layout
+
+```text
+debug/
+  cran-gcc16-repro.qmd            <- this note
+  cran-gcc16-debian/
+    Dockerfile                    <- image definition (reproduced below)
+    omp-thread-experiment.R       <- first (synthetic) thread probe
+    real-examples-timing.R        <- times the actual grpnet/cv.grpnet Rd examples
+    sptmul-nthreads-confirm.R     <- confirms the fix still honors n_threads > 1
+```
+
+Run commands from the repo root (`adelie-r/`).
+
+## The Dockerfile
+
+```dockerfile
+FROM --platform=linux/amd64 debian:sid
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      gcc-16 g++-16 gfortran-16 \
+      make \
+      ca-certificates wget curl subversion rsync \
+      xz-utils bzip2 file patch \
+      libreadline-dev \
+      libpcre2-dev \
+      zlib1g-dev \
+      libbz2-dev \
+      liblzma-dev \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      libxml2-dev \
+      libicu-dev \
+      libpng-dev libjpeg-dev libtiff-dev \
+      libcairo2-dev \
+      libuv1-dev \
+      locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# C.UTF-8 matches CRAN's "session charset: UTF-8".
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN gcc-16 --version && gfortran-16 --version
+
+# Build R-devel from svn trunk with gcc-16.
+WORKDIR /opt/src
+RUN svn checkout https://svn.r-project.org/R/trunk R-devel
+
+WORKDIR /opt/src/R-devel
+RUN ./tools/rsync-recommended
+
+# No --with-blas / --with-lapack => R's internal reference BLAS (libRblas),
+# matching a vanilla source build. Recommended packages are kept (gives Matrix).
+RUN ./configure \
+      --prefix=/opt/R/devel-gcc16 \
+      --enable-R-shlib \
+      --with-readline \
+      --with-x=no \
+      CC=gcc-16 \
+      CXX=g++-16 \
+      FC=gfortran-16 \
+      F77=gfortran-16
+
+RUN make -j"$(nproc)"
+RUN make install
+
+ENV PATH="/opt/R/devel-gcc16/bin:${PATH}"
+ENV R_HOME="/opt/R/devel-gcc16/lib/R"
+
+# Symlink R/Rscript into /usr/local/bin so they are found even by login shells
+# (`bash -lc`), whose /etc/profile resets PATH and would otherwise drop the
+# ENV PATH above.
+RUN ln -sf /opt/R/devel-gcc16/bin/R /opt/R/devel-gcc16/bin/Rscript /usr/local/bin/
+
+RUN echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' \
+      >> /opt/R/devel-gcc16/lib/R/etc/Rprofile.site
+
+RUN Rscript -e 'cat(R.version.string, "\n"); \
+                cat("platform =", R.version$platform, "\n"); \
+                cat("BLAS =", extSoftVersion()[["BLAS"]], "\n")' \
+ && echo "--- Makeconf compilers ---" \
+ && grep -E "^(CC|CXX|CXX17|FC|F77) =" /opt/R/devel-gcc16/lib/R/etc/Makeconf
+```
+
+## Build the image
+
+```sh
+docker build --platform=linux/amd64 \
+  -t adelie-debian-sid-gcc16-rdevel \
+  -f debug/cran-gcc16-debian/Dockerfile \
+  debug/cran-gcc16-debian
+```
+
+The final build step prints the R version, BLAS, and the compilers baked
+into `Makeconf`. Expect `CC = gcc-16`, `CXX = g++-16`, reference `libRblas`.
+
+## Install dependencies (persistent volume)
+
+Use a dedicated volume so compiled packages survive between runs:
+
+```sh
+docker volume create adelie-sid-gcc16-r-lib
+
+docker run --rm --platform=linux/amd64 \
+  -e R_LIBS_SITE=/usr/local/lib/R/site-library \
+  -v adelie-sid-gcc16-r-lib:/usr/local/lib/R/site-library \
+  adelie-debian-sid-gcc16-rdevel \
+  Rscript -e 'install.packages(c(
+      "Rcpp", "RcppEigen", "r2r", "stringr",
+      "testthat", "ggplot2", "gridExtra", "knitr", "rmarkdown"))'
+```
+
+## Install adelie and run its tests
+
+Mount the working tree read-only, copy it to a scratch dir, strip stale
+build artifacts, install with gcc-16, then run the test suite.
+
+```sh
+docker run --rm --platform=linux/amd64 \
+  -e R_LIBS_SITE=/usr/local/lib/R/site-library \
+  -v adelie-sid-gcc16-r-lib:/usr/local/lib/R/site-library \
+  -v "$PWD:/src:ro" \
+  adelie-debian-sid-gcc16-rdevel \
+  bash -lc 'set -e
+    rm -rf /tmp/adelie && cp -a /src /tmp/adelie
+    find /tmp/adelie/src \( -name "*.o" -o -name "*.so" -o -name "*.dll" \) -delete
+    R CMD INSTALL --library=/usr/local/lib/R/site-library /tmp/adelie
+    Rscript -e "library(testthat); library(adelie); \
+                test_dir(\"/tmp/adelie/tests/testthat\", reporter=\"summary\")"'
+```
+
+## Full R CMD check --as-cran (optional)
+
+```sh
+docker run --rm --platform=linux/amd64 \
+  -e R_LIBS_SITE=/usr/local/lib/R/site-library \
+  -v adelie-sid-gcc16-r-lib:/usr/local/lib/R/site-library \
+  -v "$PWD:/src:ro" \
+  adelie-debian-sid-gcc16-rdevel \
+  bash -lc 'set -e
+    rm -rf /tmp/adelie && cp -a /src /tmp/adelie
+    find /tmp/adelie/src \( -name "*.o" -o -name "*.so" -o -name "*.dll" \) -delete
+    cd /tmp
+    R CMD build adelie
+    R CMD check --as-cran adelie_*.tar.gz
+    cat /tmp/adelie.Rcheck/00check.log'
+```
+
+# Findings
+
+## The CRAN signature
+
+```text
+* checking examples ... [24s/12s] NOTE
+Examples with CPU (user + system) or elapsed time > 5s
+                user system elapsed
+plot.cv.grpnet 8.311  0.009   1.563
+Examples with CPU time > 2.5 times elapsed time
+                user system elapsed  ratio
+grpnet         3.292  0.016   0.315 10.502
+cv.grpnet      2.868  0.022   0.290  9.966
+plot.cv.grpnet 8.311  0.009   1.563  5.323
+```
+
+This is not slowness (elapsed is tiny). It is the `user >> elapsed` ratio:
+`user` is CPU summed over all threads, so ~10 means the work ran on ~10
+threads. CRAN flags `ratio > 2.5` because its policy caps examples at ~2
+cores.
+
+A first, important deduction: **a `ratio > 2.5` line cannot be emitted while
+`OMP_THREAD_LIMIT=2` is in force** (a 2-thread cap holds the ratio near 2).
+So whatever CRAN's general policy, the run that produced these numbers was
+*not* capped, and `adelie` must default to few threads on its own.
+
+## Reproducing with the real examples
+
+`real-examples-timing.R` runs the verbatim `grpnet.Rd` and `cv.grpnet.Rd`
+example blocks (the synthetic `omp-thread-experiment.R` used `n=100,p=200`
+toy code and under-reproduced the effect, which is why it is kept only as a
+historical first probe). Sweeping the available thread count on the 16-core
+container, `OMP_THREAD_LIMIT` unset:
+
+| `OMP_NUM_THREADS` | grpnet ratio | cv.grpnet ratio | cv.grpnet user |
+|:-----------------:|:------------:|:---------------:|:--------------:|
+|         1         |     1.00     |      1.00       |     1.134      |
+|         2         |     1.10     |      1.11       |     1.269      |
+|         4         |     1.30     |      1.33       |     1.531      |
+|         8         |     1.70     |      1.76       |     2.017      |
+|        16         |     2.75     |      2.91       |     3.412      |
+
+`elapsed` stays flat at ~1.15s throughout; only `user` grows, roughly
+`user ~= 0.98 + 0.152 * threads`. That is the signature of OpenMP threads
+spun up on work too small to benefit: they burn CPU on overhead, not work.
+Extrapolating, the ratio reaches CRAN's ~10x at ~65 threads — exactly what a
+large, uncapped CRAN pretest box delivers. The 16-core container sits at 2.9x
+on the same line. And `OMP_THREAD_LIMIT=2` collapses it to ~1.1 (consistent
+with the deduction above).
+
+## Root cause: one unguarded Eigen product
+
+It is **not** a global Eigen misbehavior, and not adelie's own loops:
+
+- `grpnet`, `cv.grpnet`, and `predict` all default `n_threads = 1`, and
+  adelie's own `#pragma omp ... num_threads(n_threads)` loops are therefore
+  pinned to one thread. They do not respond to `OMP_NUM_THREADS`.
+- On Linux, `adelie` uses no external BLAS (`EIGEN_USE_BLAS` is guarded behind
+  `#if defined(__APPLE__)`), so the only parallelism is Eigen's own kernels.
+- The ratio *does* respond to `OMP_NUM_THREADS`, so the culprit is an Eigen
+  product that consults Eigen's global thread count instead of the requested
+  `n_threads`.
+
+That product is in `MatrixNaiveDense::sp_tmul`
+(`adelie_core/matrix/matrix_naive_dense.ipp`), the kernel behind
+`predict()`'s `newx$sp_tmul(betas)` (the `X %*% beta` over the full λ path):
+
+```cpp
+if (_n_threads <= 1) {
+    out.noalias() = v * _mat.transpose();   // raw Eigen sparse x dense
+    return;
+}
+// _n_threads > 1: omp_parallel_for over the rows of v
+```
+
+The `_n_threads <= 1` branch was the intended *serial* path, but its Eigen
+product takes its thread count from the **global** `Eigen::nbThreads()`,
+which defaults to `omp_get_max_threads()` = all cores. So the "serial" branch
+silently parallelized across every core, ignoring `n_threads = 1`. Every
+other matrix routine (kronecker_eye, constraint_dense, cov_lazy, the `dgemm`
+in `utils.hpp`) already wraps its Eigen products in `Eigen::setNbThreads`;
+this one site did not.
+
+## The fix (one line)
+
+In the `_n_threads <= 1` branch of `sp_tmul`, pin Eigen to the requested
+count before the product:
+
+```cpp
+if (_n_threads <= 1) {
+    Eigen::setNbThreads(_n_threads);    // <-- added
+    out.noalias() = v * _mat.transpose();
+    return;
+}
+```
+
+`setNbThreads` is the only lever for an Eigen product — there is nothing to
+attach an OpenMP `num_threads` clause to. In this branch `_n_threads` is
+exactly 1 (the constructor forbids `< 1`), so this makes the default path
+genuinely serial without touching Eigen globally.
+
+The fix lives in the `inst/adelie` submodule on `bnaras/adelie@zero-variance`.
+
+## Verification
+
+Patched build, real examples, `OMP_THREAD_LIMIT` unset — the ratio is flat at
+1.00 regardless of cores (so it no longer relies on an env cap), and
+`elapsed` is unchanged (the parallelism gave zero speedup at these sizes):
+
+| `OMP_NUM_THREADS` | cv.grpnet ratio (unpatched) | cv.grpnet ratio (patched) |
+|:-----------------:|:---------------------------:|:-------------------------:|
+|         1         |            1.00             |           1.00            |
+|         4         |            1.33             |         **1.00**          |
+|        16         |            2.91             |         **1.00**          |
+
+Crucially, the fix is surgical, not a global throttle. `sptmul-nthreads-confirm.R`
+calls `sp_tmul` on a large matrix (X = 2000x2000, v = 200x2000 sparse) with
+the matrix built at several `n_threads`:
+
+| `n_threads` |  user | elapsed | ratio | speedup vs n=1 |
+|:-----------:|:-----:|:-------:|:-----:|:--------------:|
+|      1      | 16.73 |  16.74  | 1.00  |   1.00x (ref)  |
+|      8      | 25.90 |   3.24  | 7.99  |     5.17x      |
+|     16      | 36.02 |   2.36  | 15.30 |     7.11x      |
+
+`n_threads = 8` drives ~8-way work (ratio 7.99) with a real 5.17x wall-clock
+speedup. So the default path is serial (fixing the CRAN NOTE) while explicit
+`n_threads > 1` still fans out fully.
+
+This is why a global `Eigen::setNbThreads(1)` at load (or
+`-DEIGEN_DONT_PARALLELIZE`) was the *wrong* fix: it would flat-line this
+table to 1.00 everywhere and destroy a genuine 5x speedup for users who ask
+for threads. The per-call guard keeps both behaviors correct.


### PR DESCRIPTION
If variables are constant, standardization was failing. We deal with it by making the variance Inf, which sets the variable to zero and it is omitted, the arguably correct approach